### PR TITLE
updating to create a directory and link it

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,32 @@
 - include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
+- name: If a new directory is specified, create it and link it
+  block:
+    - name: Populate service facts
+      service_facts:
+    - name: Stop docker if it is running (for the case when it is already installed)
+      service:
+        name: docker
+        state: stopped
+      when:
+        - ansible_facts.services['docker.service'] is defined
+        - ansible_facts.services['docker.service']['state'] == "running"
+    - name: Ensure the new directory exists
+      file:
+        path: "{{ docker_link_dir }}"
+        owner: root
+        group: root
+        mode: 0711
+        state: directory
+    - name: Create the link to the new directory
+      file:
+        src: "{{ docker_link_dir }}"
+        dest: /var/lib/docker
+        state: link
+        force: true
+  when: docker_link_dir is defined
+
 - name: Install Docker.
   package:
     name: "{{ docker_package }}"


### PR DESCRIPTION
This situation may be specific to me, but when I test with 7+ different containers at a time, my `/var` gets full.  This branch allows a user to specify a location (such as on a different partition) to host the docker images.